### PR TITLE
[proj-119] feat: 매물 시세 api 구현

### DIFF
--- a/src/main/java/com/omnm/hanasset/global/exception/code/ErrorCode.java
+++ b/src/main/java/com/omnm/hanasset/global/exception/code/ErrorCode.java
@@ -10,7 +10,10 @@ public enum ErrorCode {
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 엔드포인트입니다."),
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다.");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
+
+    // RealEstate ErrorCode
+    REAL_ESTATE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 부동산이 존재하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/omnm/hanasset/realEstate/controller/RealEstateController.java
+++ b/src/main/java/com/omnm/hanasset/realEstate/controller/RealEstateController.java
@@ -1,10 +1,7 @@
 package com.omnm.hanasset.realEstate.controller;
 
 import com.omnm.hanasset.global.common.ApiResponseEntity;
-import com.omnm.hanasset.realEstate.dto.RealEstateBasicResponse;
-import com.omnm.hanasset.realEstate.dto.RealEstateDetailResponse;
-import com.omnm.hanasset.realEstate.dto.RealEstateTypeResponse;
-import com.omnm.hanasset.realEstate.dto.RealEstatesResponse;
+import com.omnm.hanasset.realEstate.dto.*;
 import com.omnm.hanasset.realEstate.service.RealEstateService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -25,6 +22,14 @@ public class RealEstateController {
     public ApiResponseEntity<RealEstatesResponse> getRealEstates(@RequestParam Long housingComplexId) {
         RealEstatesResponse realEstates = realEstateService.getRealEstates(housingComplexId);
         return ApiResponseEntity.ok("매물 리스트 조회 성공",realEstates);
+    }
+
+    @Operation(summary = "시세 정보 조회", description = "특정 매물의 시세 정보 조회를 위한 외부 API 호출에 필요한 정보를 조회한다.")
+    @ApiResponse(responseCode = "200", description = "시세 정보 조회 성공")
+    @GetMapping("/{realEstateId}/market-price")
+    public ApiResponseEntity<RealEstateMarketPriceResponse> getRealEstateMarketPrice(@PathVariable Long realEstateId) {
+        RealEstateMarketPriceResponse realEstateMarketPrice = realEstateService.getRealEstateMarketPrice(realEstateId);
+        return ApiResponseEntity.ok("시세 조회에 필요한 정보 조회 성공", realEstateMarketPrice);
     }
 
     @Operation(summary = "기본 정보 조회", description = "특정 매물의 기본 정보를 조회한다.")

--- a/src/main/java/com/omnm/hanasset/realEstate/dto/RealEstateMarketPriceResponse.java
+++ b/src/main/java/com/omnm/hanasset/realEstate/dto/RealEstateMarketPriceResponse.java
@@ -1,0 +1,24 @@
+package com.omnm.hanasset.realEstate.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "매물 시세 정보 응답")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RealEstateMarketPriceResponse {
+
+    @Schema(description = "외부 API 단지 code")
+    private Integer complexNumber;
+
+    @Schema(description = "외부 API 평형 code")
+    private Integer pyeongTypeNumber;
+
+    @Schema(description = "외부 API 거래 타입 code (B1: 전세, B2: 월세)")
+    private String tradeType;
+}

--- a/src/main/java/com/omnm/hanasset/realEstate/service/RealEstateService.java
+++ b/src/main/java/com/omnm/hanasset/realEstate/service/RealEstateService.java
@@ -1,5 +1,7 @@
 package com.omnm.hanasset.realEstate.service;
 
+import com.omnm.hanasset.global.exception.CustomException;
+import com.omnm.hanasset.global.exception.code.ErrorCode;
 import com.omnm.hanasset.realEstate.dto.*;
 import com.omnm.hanasset.realEstate.entity.RealEstate;
 import com.omnm.hanasset.realEstate.repository.RealEstateRepository;
@@ -29,21 +31,27 @@ public class RealEstateService {
                 .build();
     }
 
+    public RealEstateMarketPriceResponse getRealEstateMarketPrice(Long realEstateId) {
+        RealEstate realEstate = realEstateRepository.findById(realEstateId)
+                .orElseThrow(() -> new CustomException(ErrorCode.REAL_ESTATE_NOT_FOUND));
+        return realEstateMapper.toRealEstateMarketPriceResponse(realEstate);
+    }
+
     public RealEstateBasicResponse getRealEstateBasic(Long realEstateId) {
         RealEstate realEstate = realEstateRepository.findById(realEstateId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 부동산이 존재하지 않습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.REAL_ESTATE_NOT_FOUND));
         return realEstateMapper.toRealEstateBasicResponse(realEstate.getHousingType().getHousingComplex());
     }
 
     public RealEstateTypeResponse getRealEstateType(Long realEstateId) {
         RealEstate realEstate = realEstateRepository.findById(realEstateId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 부동산이 존재하지 않습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.REAL_ESTATE_NOT_FOUND));
         return realEstateMapper.toRealEstateTypeResponse(realEstate.getHousingType());
     }
 
     public RealEstateDetailResponse getRealEstateDetail(Long realEstateId) {
         RealEstate realEstate = realEstateRepository.findById(realEstateId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 부동산이 존재하지 않습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.REAL_ESTATE_NOT_FOUND));
         return realEstateMapper.toRealEstateDetailResponse(realEstate);
     }
 }

--- a/src/main/java/com/omnm/hanasset/realEstate/utils/RealEstateMapper.java
+++ b/src/main/java/com/omnm/hanasset/realEstate/utils/RealEstateMapper.java
@@ -1,14 +1,12 @@
 package com.omnm.hanasset.realEstate.utils;
 
-import com.omnm.hanasset.realEstate.dto.RealEstateBasicResponse;
-import com.omnm.hanasset.realEstate.dto.RealEstateDetailResponse;
-import com.omnm.hanasset.realEstate.dto.RealEstateDto;
-import com.omnm.hanasset.realEstate.dto.RealEstateTypeResponse;
+import com.omnm.hanasset.realEstate.dto.*;
 import com.omnm.hanasset.realEstate.entity.HousingComplex;
 import com.omnm.hanasset.realEstate.entity.HousingType;
 import com.omnm.hanasset.realEstate.entity.RealEstate;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 
 @Mapper(componentModel = "spring")
 public interface RealEstateMapper {
@@ -36,4 +34,19 @@ public interface RealEstateMapper {
     @Mapping(source = "housingComplex.buildingCoverageRatio", target = "buildingRatioInfo.buildingCoverageRatio")
     @Mapping(source = "housingComplex.constructionCompany", target = "constructionCompany")
     RealEstateBasicResponse toRealEstateBasicResponse(HousingComplex housingComplex);
+
+    @Mapping(source = "housingType.housingComplex.code", target = "complexNumber")
+    @Mapping(source = "housingType.code", target = "pyeongTypeNumber")
+    @Mapping(source = "type", target = "tradeType", qualifiedByName = "mapTradeType")
+    RealEstateMarketPriceResponse toRealEstateMarketPriceResponse(RealEstate realEstate);
+
+    @Named("mapTradeType")
+    default String mapTradeType(String type) {
+        if ("전세".equals(type)) {
+            return "B1";
+        } else if ("월세".equals(type)) {
+            return "B2";
+        }
+        return type;
+    }
 }


### PR DESCRIPTION
### 변경사항
부동산 매물의 시세 조회를 위해 필요한 정보를 realEstateId로 조회합니다.
- realEstates/{realEstateId}/market-price
- swagger 작성 완료

**AS-IS**
- api 구현 

**TO-BE**

### 테스트
- [ ] 테스트 코드
- [x] API 테스트 

### ETC.
